### PR TITLE
Add logging config with rotation

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,7 +45,32 @@ GEOCODER_SETTINGS = {
 }
 
 # --- Логирование ---
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 LOGGING = {
-    "level": "INFO",                # Уровень логирования (DEBUG/INFO/WARNING/ERROR)
-    "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    "version": 1,
+    "formatters": {
+        "default": {
+            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "default",
+            "level": LOG_LEVEL
+        },
+        "file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "default",
+            "level": LOG_LEVEL,
+            "filename": os.path.join(os.path.dirname(__file__), "velosocial.log"),
+            "maxBytes": 1048576,
+            "backupCount": 3,
+            "encoding": "utf-8"
+        }
+    },
+    "root": {
+        "level": LOG_LEVEL,
+        "handlers": ["console", "file"]
+    }
 }

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 # VelosocialBot/main.py
 import asyncio
 import logging
+import logging.config
 from pathlib import Path
 import yaml
 
@@ -18,10 +19,7 @@ with open(Path(__file__).parent / "assets" / "texts.yml", "r", encoding="utf-8")
     TEXTS = yaml.safe_load(f)
 
 # Настройка логгирования
-logging.basicConfig(
-    format=LOGGING["format"],
-    level=LOGGING["level"]
-)
+logging.config.dictConfig(LOGGING)
 logger = logging.getLogger(__name__)
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- configure loggers via `logging.config.dictConfig`
- allow overriding log level using `LOG_LEVEL` env var
- use rotating file handler for logs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842172d238c8324a6f080b06f667648