### PR TITLE
Deduplicate GDPR cleanup

### DIFF
--- a/db.py
+++ b/db.py
@@ -45,13 +45,3 @@ async def init_db() -> None:
 async def get_connection() -> aiosqlite.Connection:
     return await aiosqlite.connect(DB_PATH)
 
-async def cleanup_old_locations() -> None:
-    """Очищает устаревшие геоданные (GDPR)."""
-    async with await get_connection() as conn:
-        cursor = await conn.cursor()
-        await cursor.execute('''
-            UPDATE users 
-            SET lat = NULL, lon = NULL, is_visible = 0
-            WHERE last_updated < datetime('now', ?)
-        ''', (f"-{GDPR_SETTINGS['location_ttl_hours']} hours",))
-        await conn.commit()

--- a/gdpr.py
+++ b/gdpr.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 async def cleanup_old_locations() -> None:
     """Асинхронная очистка устаревших геоданных пользователей согласно GDPR"""
     try:
-        async with get_connection() as conn:
+        async with await get_connection() as conn:
             # Рассчет времени устаревания
             ttl_hours = GDPR_SETTINGS["location_ttl_hours"]
             cutoff_time = datetime.now() - timedelta(hours=ttl_hours)


### PR DESCRIPTION
## Summary
- remove duplicate `cleanup_old_locations` from the DB helpers
- use awaited connection in GDPR helper

## Testing
- `python -m py_compile db.py gdpr.py main.py events.py map.py profile.py common.py filters.py geocoder.py`

------
https://chatgpt.com/codex/tasks/task_e_68421724ebf8832499f9a5572c3e44bf