### PR TITLE
Improve error handling for message sending

### DIFF
--- a/common.py
+++ b/common.py
@@ -9,11 +9,20 @@ router = Router()
 logger = logging.getLogger(__name__)
 
 
+async def safe_answer(message: Message, *args, **kwargs) -> None:
+    """Send a message and log Telegram API errors."""
+    try:
+        await message.answer(*args, **kwargs)
+    except Exception as e:
+        logger.error(f"Ошибка отправки сообщения: {e}")
+
+
 @router.message(Command("start"))
 async def cmd_start(message: Message) -> None:
     """Обработчик команды /start"""
     try:
-        await message.answer(
+        await safe_answer(
+            message,
             "🚴♂️ Добро пожаловать в Velosocial!\n\n"
             "Я помогу вам найти компанию для велопрогулок.\n"
             "Используйте команды:\n"
@@ -22,7 +31,7 @@ async def cmd_start(message: Message) -> None:
             "/create_event - организовать заезд\n"
             "/help - справка по командам"
         )
-    except TelegramAPIError as e:
+    except Exception as e:
         logger.error(f"Ошибка в команде /start: {e}")
 
 
@@ -30,7 +39,8 @@ async def cmd_start(message: Message) -> None:
 async def cmd_help(message: Message) -> None:
     """Обработчик команды /help"""
     try:
-        await message.answer(
+        await safe_answer(
+            message,
             "📋 Список доступных команд:\n\n"
             "/start - начать работу с ботом\n"
             "/profile - управление профилем\n"
@@ -39,7 +49,7 @@ async def cmd_help(message: Message) -> None:
             "/hide_me - скрыть мои геоданные\n"
             "/help - показать эту справку"
         )
-    except TelegramAPIError as e:
+    except Exception as e:
         logger.error(f"Ошибка в команде /help: {e}")
 
 
@@ -52,10 +62,8 @@ async def error_handler(event, exception: Exception) -> None:
     )
 
     if event.message:
-        try:
-            await event.message.answer(
-                "⚠️ Произошла непредвиденная ошибка. "
-                "Попробуйте повторить действие позже."
-            )
-        except TelegramAPIError as e:
-            logger.error(f"Ошибка при отправке сообщения об ошибке: {e}")
+        await safe_answer(
+            event.message,
+            "⚠️ Произошла непредвиденная ошибка. "+
+            "Попробуйте повторить действие позже."
+        )


### PR DESCRIPTION
## Summary
- add `safe_answer` utility to log Telegram send errors
- use `safe_answer` in `cmd_start`, `cmd_help`, and `error_handler`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68421b4d21348324b703191275b41ad0