### PR TITLE
Add participant constants

### DIFF
--- a/events.py
+++ b/events.py
@@ -14,6 +14,10 @@ from database.db import get_connection
 router = Router()
 logger = logging.getLogger(__name__)
 
+# Limits for event participants
+MIN_PARTICIPANTS = 2
+MAX_PARTICIPANTS = 50
+
 
 class EventCreation(StatesGroup):
     DESCRIPTION = State()
@@ -68,7 +72,9 @@ async def handle_event_date(message: Message, state: FSMContext) -> None:
             return
 
         await state.update_data(event_date=event_date.isoformat())
-        await message.answer("👥 Введите максимальное число участников (от 2 до 50):")
+        await message.answer(
+            f"👥 Введите максимальное число участников (от {MIN_PARTICIPANTS} до {MAX_PARTICIPANTS}):"
+        )
         await state.set_state(EventCreation.PARTICIPANTS)
 
     except ValueError:
@@ -82,7 +88,7 @@ async def handle_event_participants(message: Message, state: FSMContext) -> None
     """Финализация создания события"""
     try:
         max_participants = int(message.text)
-        if not (2 <= max_participants <= 50):
+        if not (MIN_PARTICIPANTS <= max_participants <= MAX_PARTICIPANTS):
             raise ValueError
 
         data = await state.get_data()
@@ -133,7 +139,9 @@ async def handle_event_participants(message: Message, state: FSMContext) -> None
         await state.clear()
 
     except ValueError:
-        await message.answer("❌ Введите число от 2 до 50!")
+        await message.answer(
+            f"❌ Введите число от {MIN_PARTICIPANTS} до {MAX_PARTICIPANTS}!"
+        )
     except Exception as e:
         logger.error(f"Ошибка в handle_event_participants: {str(e)}")
         await message.answer("❌ Ошибка создания события")


### PR DESCRIPTION
## Summary
- define `MIN_PARTICIPANTS` and `MAX_PARTICIPANTS` in `events.py`
- use these constants in prompts and validation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684227f7d1c483249a7252adb8786eb2