### PR TITLE
Handle Telegram message failures

### DIFF
--- a/bot/handlers/events.py
+++ b/bot/handlers/events.py
@@ -10,6 +10,7 @@ from aiogram.fsm.state import State, StatesGroup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.exceptions import TelegramAPIError
 from database.db import get_connection
+from bot.utils.safe_messages import safe_answer
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -31,11 +32,11 @@ async def create_event(message: Message, state: FSMContext) -> None:
     """Инициализация создания события"""
     try:
         await state.clear()
-        await message.answer("📝 Введите описание события (например: 'Вечерний заезд по набережной'):")
+        await safe_answer(message, "📝 Введите описание события (например: 'Вечерний заезд по набережной'):")
         await state.set_state(EventCreation.DESCRIPTION)
     except Exception as e:
         logger.error(f"Ошибка в create_event: {str(e)}")
-        await message.answer("❌ Ошибка создания события")
+        await safe_answer(message, "❌ Ошибка создания события")
 
 
 @router.message(EventCreation.DESCRIPTION, F.text)
@@ -43,7 +44,7 @@ async def handle_event_description(message: Message, state: FSMContext) -> None:
     """Обработка описания события"""
     try:
         await state.update_data(description=message.text)
-        await message.answer("🗺️ Укажите маршрут (например: 'Москва, Парк Горького → Воробьевы горы'):")
+        await safe_answer(message, "🗺️ Укажите маршрут (например: 'Москва, Парк Горького → Воробьевы горы'):")
         await state.set_state(EventCreation.ROUTE)
     except Exception as e:
         logger.error(f"Ошибка в handle_event_description: {str(e)}")
@@ -54,7 +55,7 @@ async def handle_event_route(message: Message, state: FSMContext) -> None:
     """Обработка маршрута"""
     try:
         await state.update_data(route=message.text)
-        await message.answer("⏰ Введите дату и время в формате ДД.ММ.ГГГГ ЧЧ:ММ (например: 25.12.2024 18:30):")
+        await safe_answer(message, "⏰ Введите дату и время в формате ДД.ММ.ГГГГ ЧЧ:ММ (например: 25.12.2024 18:30):")
         await state.set_state(EventCreation.DATE)
     except Exception as e:
         logger.error(f"Ошибка в handle_event_route: {str(e)}")
@@ -68,17 +69,18 @@ async def handle_event_date(message: Message, state: FSMContext) -> None:
         event_date = datetime.strptime(date_str, "%d.%m.%Y %H:%M")
 
         if event_date < datetime.now():
-            await message.answer("❌ Дата не может быть в прошлом!")
+            await safe_answer(message, "❌ Дата не может быть в прошлом!")
             return
 
         await state.update_data(event_date=event_date.isoformat())
-        await message.answer(
+        await safe_answer(
+            message,
             f"👥 Введите максимальное число участников (от {MIN_PARTICIPANTS} до {MAX_PARTICIPANTS}):"
         )
         await state.set_state(EventCreation.PARTICIPANTS)
 
     except ValueError:
-        await message.answer("❌ Неверный формат даты! Используйте ДД.ММ.ГГГГ ЧЧ:ММ")
+        await safe_answer(message, "❌ Неверный формат даты! Используйте ДД.ММ.ГГГГ ЧЧ:ММ")
     except Exception as e:
         logger.error(f"Ошибка в handle_event_date: {str(e)}")
 
@@ -101,7 +103,7 @@ async def handle_event_participants(message: Message, state: FSMContext) -> None
             )
         except TelegramAPIError as e:
             logger.error(f"Ошибка создания чата: {e}", exc_info=True)
-            await message.answer("❌ Не удалось создать чат")
+            await safe_answer(message, "❌ Не удалось создать чат")
             await state.clear()
             return
 
@@ -110,7 +112,7 @@ async def handle_event_participants(message: Message, state: FSMContext) -> None
             invite_link = invite.invite_link
         except TelegramAPIError as e:
             logger.error(f"Ошибка получения ссылки на чат: {e}", exc_info=True)
-            await message.answer("❌ Не удалось создать ссылку на чат")
+            await safe_answer(message, "❌ Не удалось создать ссылку на чат")
             await state.clear()
             return
 
@@ -133,24 +135,26 @@ async def handle_event_participants(message: Message, state: FSMContext) -> None
             ))
             await conn.commit()
 
-        await message.answer(
+        await safe_answer(
+            message,
             f"✅ Событие создано!\nСсылка на чат: {invite_link}",
             disable_web_page_preview=True
         )
         await state.clear()
 
     except ValueError:
-        await message.answer(
+        await safe_answer(
+            message,
             f"❌ Введите число от {MIN_PARTICIPANTS} до {MAX_PARTICIPANTS}!"
         )
     except Exception as e:
         logger.error(f"Ошибка в handle_event_participants: {str(e)}")
-        await message.answer("❌ Ошибка создания события")
+        await safe_answer(message, "❌ Ошибка создания события")
         await state.clear()
 
 
 @router.message(Command("cancel"))
 async def cancel_event_creation(message: Message, state: FSMContext) -> None:
     """Отмена создания события"""
-    await message.answer("❌ Создание события отменено")
+    await safe_answer(message, "❌ Создание события отменено")
     await state.clear()

--- a/bot/utils/safe_messages.py
+++ b/bot/utils/safe_messages.py
@@ -1,0 +1,18 @@
+import logging
+from aiogram.types import Message
+from aiogram.exceptions import TelegramAPIError
+
+logger = logging.getLogger(__name__)
+
+async def safe_answer(message: Message, *args, **kwargs) -> bool:
+    """Safely send a reply to the user.
+
+    Logs any TelegramAPIError that occurs during message delivery.
+    Returns True if the message was successfully sent, False otherwise.
+    """
+    try:
+        await message.answer(*args, **kwargs)
+        return True
+    except TelegramAPIError as e:
+        logger.error(f"Message delivery failed: {e}", exc_info=True)
+        return False


### PR DESCRIPTION
## Summary
- wrap event handler replies with `safe_answer`
- implement helper to log TelegramAPIError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684238828d608324bcc83d81bda51b51