### PR TITLE
Improve profile contact handler error logging

### DIFF
--- a/bot/handlers/profile.py
+++ b/bot/handlers/profile.py
@@ -9,7 +9,7 @@ from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
-from database.db import get_connection
+from database.db import get_connection, DB_PATH
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -198,6 +198,7 @@ async def handle_bio(message: Message, state: FSMContext) -> None:
                        F.data.in_({"telegram", "whatsapp"}))
 async def handle_contacts(callback: CallbackQuery, state: FSMContext) -> None:
     """Финализация создания профиля"""
+    data = {}
     try:
         data = await state.get_data()
         logger.debug(f"Данные для сохранения: {data}")
@@ -245,7 +246,13 @@ async def handle_contacts(callback: CallbackQuery, state: FSMContext) -> None:
         logger.error(f"Ошибка валидации: {e}", exc_info=True)
         await callback.message.answer(f"❌ {str(e)}")
     except Exception as e:
-        logger.error(f"Критическая ошибка: {e}", exc_info=True)
-        await callback.message.answer("❌ Ошибка сохранения профиля")
+        logger.error(
+            "Критическая ошибка: %s | DB_PATH: %s | state_data: %s",
+            e,
+            DB_PATH,
+            data,
+            exc_info=True,
+        )
+        await callback.message.answer(f"❌ Ошибка сохранения профиля: {e}")
     finally:
         await state.clear()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,124 @@
+import sys
+import types
+import asyncio
+
+# Stub aiogram modules similar to other tests
+aiogram = types.ModuleType("aiogram")
+class DummyRouter:
+    def message(self, *a, **k):
+        def decorator(f):
+            return f
+        return decorator
+    def callback_query(self, *a, **k):
+        def decorator(f):
+            return f
+        return decorator
+aiogram.Router = DummyRouter
+class DummyF:
+    def __init__(self):
+        self.data = types.SimpleNamespace(in_=lambda *a, **k: None)
+        self.photo = object()
+        self.text = object()
+        self.location = object()
+aiogram.F = DummyF()
+aiogram.enums = types.ModuleType('aiogram.enums')
+aiogram.enums.ParseMode = types.SimpleNamespace(HTML='HTML')
+sys.modules['aiogram'] = aiogram
+sys.modules['aiogram.enums'] = aiogram.enums
+
+client_mod = types.ModuleType('aiogram.client')
+default_mod = types.ModuleType('aiogram.client.default')
+class DummyProps:
+    def __init__(self, *a, **k):
+        pass
+default_mod.DefaultBotProperties = DummyProps
+client_mod.default = default_mod
+sys.modules['aiogram.client'] = client_mod
+sys.modules['aiogram.client.default'] = default_mod
+
+sys.modules['aiogram.fsm'] = types.ModuleType('aiogram.fsm')
+fsm_context = types.ModuleType('aiogram.fsm.context')
+fsm_context.FSMContext = object
+sys.modules['aiogram.fsm.context'] = fsm_context
+fsm_state = types.ModuleType('aiogram.fsm.state')
+fsm_state.State = object
+fsm_state.StatesGroup = object
+sys.modules['aiogram.fsm.state'] = fsm_state
+
+types_mod = types.ModuleType('aiogram.types')
+types_mod.Message = object
+types_mod.CallbackQuery = object
+sys.modules['aiogram.types'] = types_mod
+
+filters_mod = types.ModuleType('aiogram.filters')
+class Command:
+    def __init__(self, *a, **k):
+        pass
+filters_mod.Command = Command
+sys.modules['aiogram.filters'] = filters_mod
+
+utils_mod = types.ModuleType('aiogram.utils')
+keyboard_mod = types.ModuleType('aiogram.utils.keyboard')
+keyboard_mod.InlineKeyboardBuilder = object
+utils_mod.keyboard = keyboard_mod
+sys.modules['aiogram.utils'] = utils_mod
+sys.modules['aiogram.utils.keyboard'] = keyboard_mod
+
+exceptions_mod = types.ModuleType('aiogram.exceptions')
+exceptions_mod.TelegramAPIError = Exception
+sys.modules['aiogram.exceptions'] = exceptions_mod
+
+aiosqlite_mod = types.ModuleType('aiosqlite')
+class DummyConn:
+    pass
+aiosqlite_mod.Connection = DummyConn
+sys.modules['aiosqlite'] = aiosqlite_mod
+
+from bot.handlers import profile
+
+# Patch get_connection to raise an error
+async def fail_get_connection():
+    raise RuntimeError('db broken')
+
+profile.get_connection = fail_get_connection
+
+class DummyState:
+    def __init__(self):
+        self.data = {
+            'telegram_id': 1,
+            'username': 'u',
+            'bike_type': 'road',
+            'skill_level': 'beginner',
+            'bio': 'bio'
+        }
+        self.cleared = False
+    async def get_data(self):
+        return self.data
+    async def clear(self):
+        self.cleared = True
+
+class DummyMsg:
+    def __init__(self):
+        self.text = None
+    async def answer(self, text):
+        self.text = text
+    async def edit_text(self, text):
+        self.edit = text
+
+class DummyUser:
+    username = 'user'
+    full_name = 'User'
+
+class DummyCallback:
+    def __init__(self):
+        self.data = 'telegram'
+        self.from_user = DummyUser()
+        self.message = DummyMsg()
+
+
+def test_handle_contacts_error_message_contains_exception():
+    callback = DummyCallback()
+    state = DummyState()
+    asyncio.run(profile.handle_contacts(callback, state))
+    assert 'db broken' in callback.message.text
+    assert state.cleared


### PR DESCRIPTION
## Summary
- enhance error logging in `handle_contacts`
- include exception info in user-facing error reply
- log DB path and FSM state on errors
- add regression test for the error path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f5fdf1388324b771988cf4220e30